### PR TITLE
Add route search controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ We decided to use Warsaw public transport API: https://api.um.warszawa.pl/. So W
 - [ ] Reversing the route (from A → B to B → A)
 - [ ] Estimated travel time (based on communication data)
 
+### New Route Search Functionality
+
+We have added a new route search functionality to the project. This allows users to search for a route from point A to point B using the following endpoint:
+
+- `GET /route/search?from=?&to=?`
+
+This endpoint takes two parameters, `from` and `to`, which represent the starting point and destination point of the route, respectively. The search results will provide the route details between these points.
+
 Draft of "nice to haves":
 - [ ] Planning group trips (e.g. friends meet in one place, and the system plans optimal routes for everyone).
 - [ ] Trip planning - AI generates ready-made trip plans, taking into account the user's preferences (e.g. visiting museums, dining at restaurants etc.).

--- a/src/main/java/pl/nextleveldev/smart_route/route/api/RouteSearchController.java
+++ b/src/main/java/pl/nextleveldev/smart_route/route/api/RouteSearchController.java
@@ -1,0 +1,18 @@
+package pl.nextleveldev.smart_route.route.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+
+@RestController
+@RequestMapping("/route")
+public class RouteSearchController {
+
+    @GetMapping("/search")
+    public ResponseEntity<String> searchRoute(@RequestParam String from, @RequestParam String to) {
+        // Placeholder response
+        return ResponseEntity.ok("Searching route from " + from + " to " + to);
+    }
+}


### PR DESCRIPTION
Fixes #9

Add a new controller to search for a route from point A to point B.

* **RouteSearchController.java**
  - Create a new class `RouteSearchController` in the `pl.nextleveldev.smart_route.route.api` package.
  - Annotate the class with `@RestController` and `@RequestMapping("/route")`.
  - Add a method `public ResponseEntity<String> searchRoute(@RequestParam String from, @RequestParam String to)`.
  - Annotate the method with `@GetMapping("/search")`.
  - Implement the method to return a placeholder response.

* **README.md**
  - Add a section about the new route search functionality under the MVP section.
  - Mention the new endpoint `GET /route/search?from=?&to=?`.
  - Describe the parameters `from` and `to` for the endpoint.

